### PR TITLE
v2.3 SRT形式字幕ファイルの読み込みをサポート

### DIFF
--- a/do-gagan2/MainWindow.xaml.cs
+++ b/do-gagan2/MainWindow.xaml.cs
@@ -297,14 +297,17 @@ namespace do_gagan2
             {
                 if (!LogReader.SearchTXTFile(moviePath))
                 {
-                    Console.WriteLine("どちらのファイルも存在しない");
-                    //設定形式を調べる
-                    //ログファイルパスを作成してセットする
-                    string logPath = Path.Combine(Path.GetDirectoryName(moviePath), Path.GetFileNameWithoutExtension(moviePath) + ".dggn.txt"); //2.0形式
-                    Console.WriteLine("new log:" + logPath);
-                    AppModel.CurrentLogFilePath = logPath;
-                    ListBox_Records.DataContext = AppModel.Records.Records;
-                    MI_Replace.IsEnabled = true;
+                    if (!LogReader.SearchSRTFile(moviePath))
+                    {
+                        Console.WriteLine("どのファイルも存在しない");
+                        //設定形式を調べる
+                        //ログファイルパスを作成してセットする
+                        string logPath = Path.Combine(Path.GetDirectoryName(moviePath), Path.GetFileNameWithoutExtension(moviePath) + ".dggn.txt"); //2.0形式
+                        Console.WriteLine("new log:" + logPath);
+                        AppModel.CurrentLogFilePath = logPath;
+                        ListBox_Records.DataContext = AppModel.Records.Records;
+                        MI_Replace.IsEnabled = true;
+                    }
                 }
             }
 
@@ -1065,19 +1068,30 @@ namespace do_gagan2
             //メディアファイル切り替え時の保存は抑止
             if (AppModel.CurrentLogFilePath== "suppress") return true;
 
-                if (Path.GetFileName(AppModel.CurrentLogFilePath).EndsWith(".dggn.txt"))
+            if (Path.GetFileName(AppModel.CurrentLogFilePath).EndsWith(".dggn.txt"))
             {
                 //V2フォーマットで保存
                 Console.WriteLine("Save V2");
-                body = AppModel.Records.ToString(false,FileFormatVersion.Type2);
+                body = AppModel.Records.ToString(false, FileFormatVersion.Type2);
                 enc = Encoding.GetEncoding("UTF-8");
-            } else if (Path.GetExtension(AppModel.CurrentLogFilePath) == ".txt")
+            }
+            else if (Path.GetExtension(AppModel.CurrentLogFilePath) == ".txt")
             {
                 //V1フォーマットで保存
                 Console.WriteLine("Save V1");
-                body = AppModel.Records.ToString(false,FileFormatVersion.Type1);
+                body = AppModel.Records.ToString(false, FileFormatVersion.Type1);
                 enc = Encoding.GetEncoding("Shift_JIS");
-            } else
+            } else if (Path.GetFileName(AppModel.CurrentLogFilePath).EndsWith(".srt"))
+            {
+                //srtをインポートした場合、V2フォーマットで保存し、現在のファイル拡張子を変更）
+                Console.WriteLine("Save V2");
+                body = AppModel.Records.ToString(false, FileFormatVersion.Type2);
+                enc = Encoding.GetEncoding("UTF-8");
+
+                AppModel.CurrentLogFilePath = Path.Combine(Path.GetDirectoryName(AppModel.CurrentLogFilePath), Path.GetFileNameWithoutExtension(AppModel.CurrentLogFilePath) +".dggn.txt");
+                Console.WriteLine("NewLogPath:" + AppModel.CurrentLogFilePath);
+            }
+                else
             {
                 MessageBox.Show("未知の拡張子のため上書き保存できませんでした。");
                 return false;

--- a/do-gagan2/Properties/AssemblyInfo.cs
+++ b/do-gagan2/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]

--- a/do-gagan2/do-gagan2.csproj
+++ b/do-gagan2/do-gagan2.csproj
@@ -32,8 +32,8 @@
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>index.html</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.1.0.%2a</ApplicationVersion>
+    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationVersion>2.2.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -74,6 +74,15 @@
     <SignManifests>false</SignManifests>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ByteDev.Collections, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ByteDev.Collections.2.7.0\lib\netstandard2.0\ByteDev.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="ByteDev.Strings, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ByteDev.Strings.8.3.0\lib\netstandard2.0\ByteDev.Strings.dll</HintPath>
+    </Reference>
+    <Reference Include="ByteDev.Subtitles.SubRip, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ByteDev.Subtitles.SubRip.1.0.0\lib\netstandard2.0\ByteDev.Subtitles.SubRip.dll</HintPath>
+    </Reference>
     <Reference Include="FontAwesome.WPF, Version=4.7.0.37774, Culture=neutral, PublicKeyToken=0758b07a11a4f466, processorArchitecture=MSIL">
       <HintPath>..\packages\FontAwesome.WPF.4.7.0.9\lib\net40\FontAwesome.WPF.dll</HintPath>
     </Reference>

--- a/do-gagan2/packages.config
+++ b/do-gagan2/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ByteDev.Collections" version="2.7.0" targetFramework="net472" />
+  <package id="ByteDev.Strings" version="8.3.0" targetFramework="net472" />
+  <package id="ByteDev.Subtitles.SubRip" version="1.0.0" targetFramework="net472" />
   <package id="FontAwesome.WPF" version="4.7.0.9" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
SRT形式の字幕ファイル（拡張子.srt）が動画ファイルと同じ階層に存在し、かつv2形式（拡張子.dggn.txt）、v1形式（.txt）ファイルが存在しない場合に読み込むようになりました。
なお、SRT形式はUTF-8エンコード、CRLF改行コードであることを想定しています。LF改行コードの場合は変換し上書きするかダイアログが表示されます。
