### PR TITLE
動画眼Liteの書き出しで、titleタグにファイル名を含める

### DIFF
--- a/do-gagan2/Do-gagan_Records.cs
+++ b/do-gagan2/Do-gagan_Records.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -39,7 +40,8 @@ namespace do_gagan2
             //JsonJSのヘッダー
             if (version == FileFormatVersion.JsonJS)
             {
-                result += "const scriptsJson = [\r\n";
+                string title = Path.GetFileNameWithoutExtension(AppModel.CurrentMovieFilePath) + " | 動画眼Lite";
+                result += "document.title=\"" + title + "\";\r\nconst scriptsJson = [\r\n";
             }
 
             List<Dogagan_Record> sortedRecords = _records.OrderBy(r => r.TimeStamp).ToList();


### PR DESCRIPTION
HTMLファイルは固定のまま、jsファイル側で動的に変更するための行を追加。